### PR TITLE
Slowcontrol manager

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -46,6 +46,7 @@ set(ANALYSIS_PHYSICS
   physics/common/DebugPhysics.cc
   physics/common/ReconstructCheck.cc
   physics/tpc/PhysicsStats.cc
+  physics/SlowcontrolManager.cc
   )
 
 set(ANALYSIS_PLOT

--- a/src/analysis/data/Slowcontrol.cc
+++ b/src/analysis/data/Slowcontrol.cc
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <stdexcept>
+#include <limits>
 
 using namespace std;
 using namespace ant;
@@ -20,3 +21,16 @@ void SlowcontrolRequestable::Request()
     requested = true;
 }
 
+
+
+template <> ant::analysis::data::ReqestableVariable<double>::ReqestableVariable():
+    data(std::numeric_limits<double>::quiet_NaN())
+{
+
+}
+
+template <> ant::analysis::data::ReqestableVariable<std::int64_t>::ReqestableVariable():
+    data(std::numeric_limits<int64_t>::lowest())
+{
+
+}

--- a/src/analysis/data/Slowcontrol.h
+++ b/src/analysis/data/Slowcontrol.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <cstdint>
 
 namespace ant {
 namespace analysis {
@@ -18,10 +19,14 @@ class ReqestableVariable: public SlowcontrolRequestable {
 protected:
     T data;
 public:
+    ReqestableVariable(): data({}) {}
 
     const T& operator()() const { return data; }
           T& operator()() { return data; }
 };
+
+template <> ReqestableVariable<double>::ReqestableVariable();
+template <> ReqestableVariable<std::int64_t>::ReqestableVariable();
 
 
 class Slowcontrol {

--- a/src/analysis/physics/Physics.h
+++ b/src/analysis/physics/Physics.h
@@ -64,7 +64,7 @@ public:
 template<class T>
 std::unique_ptr<Physics> physics_factory(PhysOptPtr opts)
 {
-    return std::move(std_ext::make_unique<T>(opts));
+    return std_ext::make_unique<T>(opts);
 }
 
 using physics_creator = std::function<std::unique_ptr<Physics>(PhysOptPtr)>;

--- a/src/analysis/physics/PhysicsManager.cc
+++ b/src/analysis/physics/PhysicsManager.cc
@@ -95,8 +95,8 @@ void PhysicsManager::ProcessEventBuffer(
     // if running is already false,
     // flush the buffer no matter what...
     bool flush = !running;
-//    if(flush)
-//        VLOG(5) << "Flushing " << eventbuffer.size() << " events from eventbuffer";
+    if(flush)
+        VLOG(5) << "Flushing " << eventbuffer.size() << " events from eventbuffer";
 
     TID runUntil = slowcontrol_mgr.UpdateSlowcontrolData(slowcontrol_data);
 
@@ -104,7 +104,7 @@ void PhysicsManager::ProcessEventBuffer(
         return;
 
     while(!eventbuffer.empty()) {
-
+        // running might change to false here in this loop
         if(!running && !flush)
             return;
 
@@ -177,6 +177,7 @@ void PhysicsManager::ReadFrom(
                 finished_reading = true;
                 break;
             }
+
             eventbuffer.emplace(move(event));
             nEventsRead++;
         }

--- a/src/analysis/physics/PhysicsManager.cc
+++ b/src/analysis/physics/PhysicsManager.cc
@@ -139,7 +139,7 @@ void PhysicsManager::ReadFrom(
         return;
 
     if(physics.empty()) {
-        throw std::runtime_error("No Analysis Instances activated. Will not analyse anything.");
+        throw Exception("No Analysis Instances activated. Will not analyse anything.");
     }
 
 
@@ -176,6 +176,9 @@ void PhysicsManager::ReadFrom(
                 VLOG(5) << "No more events to read, finish.";
                 finished_reading = true;
                 break;
+            }
+            if(eventbuffer.size()>20000) {
+                throw Exception("SlowControl buffering reached maximum size without becoming complete.");
             }
 
             eventbuffer.emplace(move(event));

--- a/src/analysis/physics/PhysicsManager.cc
+++ b/src/analysis/physics/PhysicsManager.cc
@@ -104,8 +104,10 @@ void PhysicsManager::ProcessEventBuffer(
         return;
 
     while(!eventbuffer.empty()) {
+
         if(!running && !flush)
             return;
+
         if(nEventsProcessed>=maxevents)
             return;
 
@@ -178,7 +180,12 @@ void PhysicsManager::ReadFrom(
             nEventsRead++;
         }
 
-        ProcessEventBuffer(maxevents, running, header);
+        if(slowcontrol_mgr.isComplete()) {
+            VLOG(5) << "Slowcontrol set complete. Processing event buffer.";
+            ProcessEventBuffer(maxevents, running, header);
+        } else {
+            VLOG(5) << "Finished reading but slowcontrol block not complete. Dropping remaining " << eventbuffer.size() << " events.";
+        }
     }
 
     VLOG(5) << "First EventId processed: " << header.FirstID;

--- a/src/analysis/physics/PhysicsManager.cc
+++ b/src/analysis/physics/PhysicsManager.cc
@@ -164,7 +164,8 @@ void PhysicsManager::ReadFrom(
         if(finished_reading)
             break;
 
-        while(!slowcontrol_mgr.isComplete()) {
+        do
+        {
             if(!running || nEventsRead>=maxevents) {
                 VLOG(5) << "End of reading requested";
                 finished_reading = true;
@@ -179,6 +180,7 @@ void PhysicsManager::ReadFrom(
             eventbuffer.emplace(move(event));
             nEventsRead++;
         }
+        while(!slowcontrol_mgr.isComplete());
 
         if(slowcontrol_mgr.isComplete()) {
             VLOG(5) << "Slowcontrol set complete. Processing event buffer.";

--- a/src/analysis/physics/PhysicsManager.h
+++ b/src/analysis/physics/PhysicsManager.h
@@ -78,6 +78,10 @@ public:
                   );
 
     void ShowResults();
+
+    class Exception : public std::runtime_error {
+        using std::runtime_error::runtime_error; // use base class constructor
+    };
 };
 
 }} // namespace ant::analysis

--- a/src/analysis/physics/PhysicsManager.h
+++ b/src/analysis/physics/PhysicsManager.h
@@ -3,8 +3,8 @@
 #include "Physics.h"
 #include "tree/TSlowControl.h"
 #include "analysis/data/Slowcontrol.h"
+#include "analysis/physics/SlowcontrolManager.h"
 
-#include <queue>
 
 namespace ant {
 
@@ -36,7 +36,8 @@ protected:
     bool InitReaders(readers_t readers_);
     bool TryReadEvent(std::unique_ptr<data::Event>& event);
 
-    std::map<TSlowControl::Key, std::queue< std::unique_ptr<TSlowControl> > > slowcontrol;
+    slowontrol::Manager slowcontrol_mgr;
+    data::Slowcontrol slowcontrol_data;
 
     std::queue< std::unique_ptr<data::Event> > eventbuffer;
 
@@ -44,9 +45,6 @@ protected:
 
     void ProcessEventBuffer(long long maxevents, bool& running, TAntHeader& header);
     void ProcessEvent(std::unique_ptr<data::Event> event);
-
-
-    ant::analysis::data::Slowcontrol slc;
 
 public:
 
@@ -67,7 +65,7 @@ public:
         if(pc==nullptr)
             return;
 
-        pc->Initialize(slc);
+        pc->Initialize(slowcontrol_data);
         physics.emplace_back(std::move(pc));
     }
 

--- a/src/analysis/physics/SlowcontrolManager.cc
+++ b/src/analysis/physics/SlowcontrolManager.cc
@@ -45,11 +45,24 @@ bool slowontrol::Manager::isComplete() const {
     return true;
 }
 
+TID slowontrol::Manager::FindMinimalTID() const
+{
+    TID minimal;
+
+    for(const auto& entry : slowcontrol) {
+        const buffer_t& buffer = entry.second;
+        const auto& slread = buffer.front();
+        minimal = min(minimal, slread->ID);
+    }
+
+    return minimal;
+}
+
 TID slowontrol::Manager::UpdateSlowcontrolData(data::Slowcontrol& slc)
 {
 
     if(isComplete()) {
-        auto validuntil = minimal_in_buffer;
+        auto validuntil = minimal_in_buffer.IsInvalid() ? FindMinimalTID() : minimal_in_buffer;
 
         minimal_in_buffer = TID();
 

--- a/src/analysis/physics/SlowcontrolManager.cc
+++ b/src/analysis/physics/SlowcontrolManager.cc
@@ -1,0 +1,71 @@
+#include "SlowcontrolManager.h"
+#include "tree/TSlowControl.h"
+#include "input/detail/SlowcontrolCreator.h"
+#include <stdexcept>
+
+using namespace ant;
+using namespace ant::analysis;
+
+
+TID slowontrol::Manager::min(const TID& a, const TID& b)
+{
+    if(a.IsInvalid())
+        return b;
+    if(!b.IsInvalid())
+        return a;
+    return std::min(a,b);
+}
+
+void slowontrol::Manager::SetRequiredKeys(const std::list<ant::TSlowControl::Key> keys)
+{
+    for(const auto& key : keys) {
+        const auto entry = slowcontrol.find(key);
+        if(entry == slowcontrol.end()) {
+            slowcontrol[key] = buffer_t();
+        }
+    }
+}
+
+void slowontrol::Manager::ProcessSlowcontrol(std::unique_ptr<const TSlowControl> data)
+{
+    auto entry = slowcontrol.find(data->GetKey());
+    if(entry != slowcontrol.end()) {
+        buffer_t& buffer = entry->second;
+        buffer.emplace(move(data));
+    }
+}
+
+bool slowontrol::Manager::isComplete() const {
+
+    for(const auto& entry : slowcontrol) {
+        if(entry.second.empty())
+            return false;
+    }
+
+    return true;
+}
+
+TID slowontrol::Manager::UpdateSlowcontrolData(data::Slowcontrol& slc)
+{
+
+    if(isComplete()) {
+        auto validuntil = minimal_in_buffer;
+
+        minimal_in_buffer = TID();
+
+        for(auto& entry : slowcontrol) {
+            buffer_t& buffer = entry.second;
+            auto slread = move(buffer.front());
+            buffer.pop();
+
+            FillSlowcontrol(slc, *slread);
+
+            minimal_in_buffer = min(minimal_in_buffer, slread->ID);
+        }
+
+        return validuntil;
+    }
+
+    return TID();
+
+}

--- a/src/analysis/physics/SlowcontrolManager.h
+++ b/src/analysis/physics/SlowcontrolManager.h
@@ -20,7 +20,7 @@ protected:
 
     TID minimal_in_buffer;
 
-    TID min(const TID& a, const TID& b);
+    static TID min(const TID& a, const TID& b);
 
 public:
     Manager() = default;
@@ -30,6 +30,8 @@ public:
     void ProcessSlowcontrol(std::unique_ptr<const TSlowControl> data);
 
     bool isComplete() const;
+
+    TID FindMinimalTID() const;
 
     TID UpdateSlowcontrolData(data::Slowcontrol& slc);
 

--- a/src/analysis/physics/SlowcontrolManager.h
+++ b/src/analysis/physics/SlowcontrolManager.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "tree/TSlowControl.h"
+#include "analysis/data/Slowcontrol.h"
+
+#include <map>
+#include <queue>
+#include <memory>
+#include <list>
+
+namespace ant {
+namespace analysis {
+namespace slowontrol {
+
+class Manager {
+protected:
+
+    using buffer_t = std::queue<std::unique_ptr<const TSlowControl>>;
+    std::map<TSlowControl::Key, buffer_t> slowcontrol;
+
+    TID minimal_in_buffer;
+
+    TID min(const TID& a, const TID& b);
+
+public:
+    Manager() = default;
+
+    void SetRequiredKeys(const std::list<TSlowControl::Key> keys);
+
+    void ProcessSlowcontrol(std::unique_ptr<const TSlowControl> data);
+
+    bool isComplete() const;
+
+    TID UpdateSlowcontrolData(data::Slowcontrol& slc);
+
+};
+
+}
+}
+}

--- a/src/analysis/plot/SmartHist.cc
+++ b/src/analysis/plot/SmartHist.cc
@@ -12,5 +12,8 @@ SmartHist1<std::string> SmartHist1<std::string>::makeHist(
     const std::string& name,
     HistogramFactory& factory)
 {
-    return move(makeHist([] (const std::string& data) -> const char* { return data.c_str();}, title, xlabel, ylabel, bins, name, factory));
+    auto converter = [] (const std::string& data) -> const char* {
+        return data.c_str();
+    };
+    return makeHist(converter, title, xlabel, ylabel, bins, name, factory);
 }

--- a/src/analysis/utils/matcher.h
+++ b/src/analysis/utils/matcher.h
@@ -94,7 +94,7 @@ std::list< scored_match<typename List1::value_type, typename List2::value_type> 
         ++i;
     }
 
-    return std::move(scores);
+    return scores;
 }
 }
 }

--- a/src/analysis/utils/root-addons.cc
+++ b/src/analysis/utils/root-addons.cc
@@ -14,7 +14,7 @@ std::shared_ptr<TCutG> root::makeTCutG(const std::string& name, const std::initi
         cut->SetPoint(i++,point.first, point.second);
     }
 
-    return move(cut);
+    return cut;
 
 }
 
@@ -27,6 +27,6 @@ std::shared_ptr<TGraph> root::makeTGraph(const std::initializer_list<std::pair<d
         cut->SetPoint(i++,point.first, point.second);
     }
 
-    return move(cut);
+    return cut;
 
 }

--- a/src/base/Tree.h
+++ b/src/base/Tree.h
@@ -32,7 +32,7 @@ public:
     static snode_t makeNode(args_t&&... args) {
         auto n = std::shared_ptr<Tree>(new Tree(std::forward<args_t>(args)...));
         n->self = n;
-        return std::move(n);
+        return n;
     }
 
     bool isRoot() const { return partent.expired(); }
@@ -59,7 +59,7 @@ public:
         auto n = makeNode(std::forward<args_t>(args)...);
         n->partent = Self();
         daughters.emplace_back(n);
-        return std::move(n);
+        return n;
     }
 
     void setParent(snode_t& p) {

--- a/src/base/detail/CmdLine.h
+++ b/src/base/detail/CmdLine.h
@@ -224,7 +224,7 @@ private:
         std::unique_ptr<T> add(args_t&&... args) {
            std::unique_ptr<T> a(new T(std::forward<args_t>(args)...));
            add(*a);
-           return std::move(a);
+           return a;
         }
 
     /**

--- a/src/expconfig/setups/SetupRegistry.cc
+++ b/src/expconfig/setups/SetupRegistry.cc
@@ -23,7 +23,7 @@ SetupRegistry& SetupRegistry::get()
     return instance;
 }
 
-void SetupRegistry::add(setup_creator creator)
+void SetupRegistry::add(Creator creator)
 {
     setup_creators.push_back(creator);
 }
@@ -45,7 +45,7 @@ void SetupRegistry::destroy()
     setups.clear();
 }
 
-SetupRegistration::SetupRegistration(setup_creator creator)
+SetupRegistration::SetupRegistration(SetupRegistry::Creator creator)
 {
     SetupRegistry::get().add(creator);
 }

--- a/src/expconfig/setups/SetupRegistry.h
+++ b/src/expconfig/setups/SetupRegistry.h
@@ -9,42 +9,41 @@ namespace expconfig {
 
 class Setup;
 
-// stuff for semiauto-registering the setups
-// don't forget to use AUTO_REGISTER_SETUP
-// note that linking order is important to get this registry
-// properly working, see CMakeLists.txt
-
-template<class T>
-std::shared_ptr<Setup> setup_factory()
-{
-    return std::move(std::make_shared<T>());
-}
-
-using setup_creator = std::function<std::shared_ptr<Setup>()>;
-
+/**
+ * @brief The SetupRegistry class semi-automatically registers Setups
+ *
+ * \note don't forget to use AUTO_REGISTER_SETUP
+ * \note linking order is important to get this registry properly working, see CMakeLists.txt
+ */
 class SetupRegistry
 {
+friend class SetupRegistration;
+
 private:
-    using setup_creators_t = std::list<setup_creator>;
+    using Creator = std::function<std::shared_ptr<Setup>()>;
+    using setup_creators_t = std::list<Creator>;
     using setups_t = std::list< std::shared_ptr<Setup> >;
     setup_creators_t setup_creators;
     setups_t setups;
     void init_setups();
 public:
     static SetupRegistry& get();
-    void add(setup_creator);
+    void add(Creator);
     setups_t::iterator begin();
     setups_t::iterator end();
     void destroy();
 };
 
+/**
+ * @brief The SetupRegistration class is instantiated for each setup
+ */
 class SetupRegistration
 {
 public:
-    SetupRegistration(setup_creator);
+    SetupRegistration(SetupRegistry::Creator);
 };
 
 #define AUTO_REGISTER_SETUP(setup) \
-    SetupRegistration _setup_registration_ ## setup(setup_factory<setup>);
+    SetupRegistration _setup_registration_ ## setup(std::make_shared<setup>);
 
 }} // namespace ant::expconfig

--- a/src/unpacker/UnpackerAcqu.cc
+++ b/src/unpacker/UnpackerAcqu.cc
@@ -39,7 +39,7 @@ std::unique_ptr<TDataRecord> UnpackerAcqu::NextItem() noexcept
     // we also convert the unique_ptr here to some shared_ptr
     auto element = move(queue.front());
     queue.pop_front();
-    return move(element);
+    return element;
 }
 
 


### PR DESCRIPTION
Handle the slowcontrol data correctly and provide it transparently to physics classes. This branch will be merged once it also works with input sources providing no slow control data at all. So some "default slowcontrol data" source is needed if physics modules still want some slowcontrol...