### PR TITLE
Cmake: check if gold linker is available and use it (useful for ubunt…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,16 @@ if(CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR AND NOT MSVC_IDE)
     )
 endif()
 
+# check if gold linker is available and use it
+execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+if ("${LD_VERSION}" MATCHES "GNU gold")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-fuse-ld=gold")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-fuse-ld=gold")
+    message(WARNING "GNU gold linker will be used.")
+else ()
+    message(WARNING "GNU gold linker isn't available, using the default system linker.")
+endif ()
+
 include(cmake/settings.cmake)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 


### PR DESCRIPTION
Without changing the standard linker for the system it works at least well when gold linker is installed (package binutils, standard package on Ubuntu). Without it doesn't build.